### PR TITLE
Updated dev setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,40 +3,57 @@
 This is the service api for persisting application related information to the back end database and
 may well be used to fire requests to other services.
 
-* Ruby version 
-    * Ruby version 2.5.1
-    * Rails 5
+## Setting up development environment
 
+### Ruby version
 
-* System dependencies
-    * postgres 10.5  -> see setup below
+* Ruby version 2.5.1
+* Rails 5
 
-* Configuration
-   
-    ```brew install postgres```
-    
-    ```bundle install```
+For [rbenv](https://github.com/rbenv/rbenv) users:
 
+```
+rbenv install $(cat .ruby-version)
+```
 
-* How to run the test suite
-    * ```bundle exec rspec spec```
+### System dependencies
 
-* Services (job queues, cache servers, search engines, etc.)
-    
+* Postgresql 10.5
 
-* Deployment instructions
-    * check the code out and run ```rails s```
+```
+brew install postgres
+```
 
-* play with application
-    Once the server is started you can actualy use postman to fire requests using the endpoints below
-    
+### Setup
 
-* Developer local Endpoints
-    * ``http://localhost:3000/api/v1/applications``
-        * Only POST is supported at the moment so this wil create an application and retrun application ref
-    * ``http://localhost:3000/api/v1/status``
-        * Only GET is supported at the moment not sure anything else is needed here
+Install gems, set environment files and setup database.
 
+```
+# From the root of the project execute the following command:
+bin/setup
+```
+
+### Run the application server
+
+```
+bin/rails s
+```
+
+### Available API endpoints
+
+Once the server is started you can actualy use postman to fire requests using the endpoints below:
+
+```
+bundle exec rake routes | grep v1_
+```
+
+## Testing
+
+How to run the test suite:
+
+```
+bundle exec rspec
+```
 
 ## Docker
 
@@ -47,41 +64,51 @@ Alpine images are usually very lightweight and such are preferred choice for dep
 
 In order to create a local build you can run
 
-```docker build -t laa-apply-for-legalaid-api .```
-
+```
+docker build -t laa-apply-for-legalaid-api .
+```
 
 And then run the image using
 
-```docker container run  -d -p 3000:3000 laa-apply-for-legalaid-api```
+```
+docker container run  -d -p 3000:3000 laa-apply-for-legalaid-api
+```
 
+## Troubleshooting
 
-## Postgres Sql
+### Postgresql
 
 If you already have an installation of postgres you might want to use it.
 For development mode i am going for the simplest setup without setting any specific roles or users
 
 If you dont have postgres installed then you can run the following command to get up and running quickly
 
-```docker run  -d -v pg-data:/var/lib/postgresql/data -p 5432:5432  --name postgres  postgres:10.5```
- 
- the 10.5 version appears to be the latest and most likely the one we will be using in RDS.
- 
- The above will start a postgres server and expose it on ```localhost:5432```
- 
- 
- If you are running this for the first time you will have to run the following commands form within the project
- 
- ```rake db:setup```
- 
- ```rake db:migrate```
- 
- 
-For every other time you do a pull it might be a good idea to 
-```rake db:migrate```
+```
+docker run  -d -v pg-data:/var/lib/postgresql/data -p 5432:5432  --name postgres  postgres:10.5
+```
+
+the 10.5 version appears to be the latest and most likely the one we will be using in RDS.
+
+The above will start a postgres server and expose it on ```localhost:5432```
+
+If you are running this for the first time you will have to run the following commands form within the project
+
+```
+rake db:setup
+rake db:migrate
+```
+
+For every other time you do a pull it might be a good idea to
+
+```
+rake db:migrate
+```
 
 It's also good idea at this pint to rerun the tests.
 
-```bundle exec rspec spec```
+```
+bundle exec rspec
+```
 
 If all is well the tests will now work with postgres database
 The tests will create a test schema and delete the data  once its done.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
 
   namespace 'v1' do
-
     resources :status, only: [:index]
     resources :applications, only: [:create]
   end


### PR DESCRIPTION
- Replaced step by step instructions with script that sets up the local environment in one go
- Updated references to the available API endpoints by checking the current available routes

#### Why 

Mainly to reduce the overhead of step by step instructions in the README and delegate that to scripts that are more likely to be up to date.