### PR TITLE
Add endpoint to return an application

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ gem 'bootsnap', '>= 1.1.0', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'faker', '>=1.9.1'
+  gem 'json_expressions'
   gem 'rspec-rails', '~> 3.7'
   gem 'rubocop', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,8 @@ GEM
     crass (1.0.4)
     diff-lcs (1.3)
     erubi (1.7.1)
+    faker (1.9.1)
+      i18n (>= 0.7)
     fast_jsonapi (1.3)
       activesupport (>= 4.2)
     ffi (1.9.25)
@@ -60,6 +62,7 @@ GEM
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.1)
+    json_expressions (0.9.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -172,7 +175,9 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
+  faker (>= 1.9.1)
   fast_jsonapi
+  json_expressions
   listen (>= 3.0.5, < 3.2)
   pg
   puma (~> 3.11)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,5 @@
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordNotFound do
+    render json: {}, status: :not_found
+  end
 end

--- a/app/controllers/v1/applications_controller.rb
+++ b/app/controllers/v1/applications_controller.rb
@@ -1,15 +1,17 @@
 class V1::ApplicationsController < ApplicationController
   def create
-    legalaid_application = LegalAidApplication.new
+    application = LegalAidApplication.new
 
-    if legalaid_application.save
-      # TODO: figure out why this render function doesnt automatically use  the serializer.
-      render json: LegalAidApplicationSerializer.new(legalaid_application).serialized_json, status: :created, serializer: LegalAidApplicationSerializer
+    if application.save
+      render json: LegalAidApplicationSerializer.new(application).serialized_json, status: :created
     else
-      # TODO: probably a better way to do this error return something like a global errrors handler if save fails
-      render json: { status: 'ERROR', message: 'Failed to create application', data: legalaid_application.errors }, status: :bad_request
+      render json: { status: 'ERROR', message: 'Failed to create application', data: application.errors }, status: :bad_request
     end
+  end
 
-    # respond_with @legalaid_application
+  def show
+    application = LegalAidApplication.find_by!(application_ref: params[:id])
+    options = { include: [:applicant] }
+    render json: LegalAidApplicationSerializer.new(application, options).serialized_json
   end
 end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -1,4 +1,5 @@
 class LegalAidApplication < ApplicationRecord
+  belongs_to :applicant, optional: true
   before_create :create_app_ref
 
   private

--- a/app/serializers/applicant_serializer.rb
+++ b/app/serializers/applicant_serializer.rb
@@ -1,0 +1,5 @@
+class ApplicantSerializer
+  include FastJsonapi::ObjectSerializer
+  attribute :name
+  attribute :date_of_birth
+end

--- a/app/serializers/legal_aid_application_serializer.rb
+++ b/app/serializers/legal_aid_application_serializer.rb
@@ -1,4 +1,5 @@
 class LegalAidApplicationSerializer
   include FastJsonapi::ObjectSerializer
   attribute :application_ref
+  belongs_to :applicant
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   namespace 'v1' do
     resources :status, only: [:index]
-    resources :applications, only: [:create]
+    resources :applications, only: [:create, :show]
   end
 end

--- a/spec/requests/legalaid_application_spec.rb
+++ b/spec/requests/legalaid_application_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'json_expressions/rspec'
 
 RSpec.describe 'Legal aid applications' do
   let(:response_json) { JSON.parse(response.body) }
@@ -8,6 +9,53 @@ RSpec.describe 'Legal aid applications' do
       post '/v1/applications'
       expect(response_json['data']['attributes']['application_ref']).not_to be_empty
       expect(response.status).to eql(201)
+      expect(response.content_type).to eql('application/json')
+    end
+  end
+
+  describe 'GET /v1/applications/:id' do
+    let(:applicant_name) { Faker::Name.name }
+    let(:applicant_date_of_birth) { Faker::Date.birthday(18, 100) }
+    let(:applicant) { Applicant.create(name: applicant_name, date_of_birth: applicant_date_of_birth) }
+    let(:legal_aid_application) { LegalAidApplication.create(applicant: applicant) }
+    let(:application_ref) { legal_aid_application.application_ref }
+
+    context 'with a non-existant application reference' do
+      let(:application_ref) { SecureRandom.uuid }
+
+      it 'returns a 404 error' do
+        get '/v1/applications/' + application_ref
+        expect(response.status).to eql(404)
+        expect(response.content_type).to eql('application/json')
+      end
+    end
+
+    it 'returns a complete application' do
+      get '/v1/applications/' + application_ref
+
+      expected_json = {
+        'data' =>
+          { 'id' => legal_aid_application.id.to_s,
+            'type' => 'legal_aid_application',
+            'attributes' =>
+              { 'application_ref' => application_ref },
+            'relationships' =>
+                { 'applicant' =>
+                  { 'data' =>
+                    { 'id' => applicant.id.to_s,
+                      'type' => 'applicant' } } } },
+        'included' => [
+          { 'id' => applicant.id.to_s,
+            'type' => 'applicant',
+            'attributes' =>
+            { 'name' => applicant_name,
+              'date_of_birth' => applicant_date_of_birth.to_s } }
+        ]
+      }
+
+      expect(response.body).to match_json_expression(expected_json)
+      expect(response.status).to eql(200)
+      expect(response.content_type).to eql('application/json')
     end
   end
 end


### PR DESCRIPTION
The Citizen application needs to be able to retrieve application and
applicant data from the database based on application reference.

This adds an endpoint to do this: /v1/applications/:id

* Add show action to applications resource in routes.rb.
* Define show method in ApplicationsController.rb.
* Add test to requests/legal_aid_application_spec.rb.
* Install webmock and faker gems to support testing.