### PR TITLE
Add a PR template including task list

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,17 @@
+
+## What
+
+[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)
+
+Describe what you did and why.
+
+## Checklist
+
+Before you ask people to review this PR:
+
+- [ ] Tests and rubocop should be passing: `bundle exec rake`
+- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
+- [ ] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
+- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
+- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
+- [ ] You should have checked that the commit messages say why the change was made.


### PR DESCRIPTION
## What

At our dev meeting today we agreed:

- what we think the person raising a pull request should check before asking
  someone to spend time reviewing it.
- that there should be some basic description of what the PR does
- that we should link to the story in JIRA

This is a PR template that sets out the structure we expect; a description,
link to the story and a task list to help the person raising the PR to remember
the things to check before requesting review.

## How to review

This is identical to the template that was introduced in ministryofjustice/laa-apply-for-legal-aid-citizen-frontend#25 so the content has already been reviewed. But if you want, you can review the content again.