### PR TITLE
Split client name into first_name and last_name

### DIFF
--- a/app/controllers/v1/applicants_controller.rb
+++ b/app/controllers/v1/applicants_controller.rb
@@ -40,7 +40,7 @@ module V1
     end
 
     def applicant_params
-      params.require(:data).require(:attributes).permit(:name, :date_of_birth, :application_ref)
+      params.require(:data).require(:attributes).permit(:first_name, :last_name, :date_of_birth, :application_ref)
     end
   end
 end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -1,7 +1,7 @@
 class Applicant < ApplicationRecord
   has_one :legal_aid_application
 
-  validates :name, :date_of_birth, presence: true
+  validates :first_name, :last_name, :date_of_birth, presence: true
 
   validate :validate_date_of_birth
 

--- a/app/serializers/applicant_serializer.rb
+++ b/app/serializers/applicant_serializer.rb
@@ -1,5 +1,5 @@
 class ApplicantSerializer
   include FastJsonapi::ObjectSerializer
-  attribute :name
+  attribute :first_name, :last_name
   attribute :date_of_birth
 end

--- a/app/services/save_applicant.rb
+++ b/app/services/save_applicant.rb
@@ -1,10 +1,10 @@
 class SaveApplicant
-  def self.call(name:, date_of_birth:, application_ref:)
-    new.call(name: name, date_of_birth: date_of_birth, application_ref: application_ref)
+  def self.call(first_name:, last_name:, date_of_birth:, application_ref:)
+    new.call(first_name: first_name, last_name: last_name, date_of_birth: date_of_birth, application_ref: application_ref)
   end
 
-  def call(name:, date_of_birth:, application_ref:)
-    applicant = Applicant.new(name: name, date_of_birth: date_of_birth)
+  def call(first_name:, last_name:, date_of_birth:, application_ref:)
+    applicant = Applicant.new(first_name: first_name, last_name: last_name, date_of_birth: date_of_birth)
     app = LegalAidApplication.find_by(application_ref: application_ref)
     if applicant.valid? && app
       applicant.save

--- a/db/migrate/20180913101947_rename_name_to_first_name.rb
+++ b/db/migrate/20180913101947_rename_name_to_first_name.rb
@@ -1,0 +1,5 @@
+class RenameNameToFirstName < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :applicants, :name, :first_name
+  end
+end

--- a/db/migrate/20180913103146_add_last_name_to_applicants.rb
+++ b/db/migrate/20180913103146_add_last_name_to_applicants.rb
@@ -1,0 +1,5 @@
+class AddLastNameToApplicants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :applicants, :last_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_11_143012) do
+ActiveRecord::Schema.define(version: 2018_09_13_103146) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "applicants", force: :cascade do |t|
-    t.string "name"
+    t.string "first_name"
     t.date "date_of_birth"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "last_name"
   end
 
   create_table "application_proceeding_types", force: :cascade do |t|

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Applicant, type: :model do
   subject { described_class.new }
 
   before do
-    subject.name = 'John Doe'
+    subject.first_name = 'John'
+    subject.last_name = 'Doe'
     subject.date_of_birth = Date.new(1988, 0o2, 0o1)
   end
 
@@ -12,9 +13,16 @@ RSpec.describe Applicant, type: :model do
     expect(subject).to be_valid
   end
 
-  it 'is not valid without a name' do
-    subject.name = ''
+  it 'is not valid without a first name' do
+    subject.first_name = ''
     expect(subject).to_not be_valid
+    expect(subject.errors[:first_name]).to include("can't be blank")
+  end
+
+  it 'is not valid without a last name' do
+    subject.last_name = ''
+    expect(subject).to_not be_valid
+    expect(subject.errors[:last_name]).to include("can't be blank")
   end
 
   it 'is not valid without a date of birth' do

--- a/spec/requests/create_applicant_spec.rb
+++ b/spec/requests/create_applicant_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe 'Legal aid applications' do
       'data': {
         'type': 'legal_aid_applicant',
         'attributes': {
-          'name': 'John Doe',
+          'first_name': 'John',
+          'last_name': 'Doe',
           'date_of_birth': '1991-12-01',
           'application_ref': application.application_ref
         }
@@ -30,8 +31,9 @@ RSpec.describe 'Legal aid applications' do
       post '/v1/applicants', params: body, headers: headers
       expect(response.status).to eql(201)
       expect(response.content_type).to eql('application/json')
-      expect(response_json['data']['attributes']['name']).to eq('John Doe')
-      expect(response_json['data']['attributes']['date_of_birth']).to eq('1991-12-01')
+      expect(response_json.dig('data', 'attributes', 'first_name')).to eq('John')
+      expect(response_json.dig('data', 'attributes', 'last_name')).to eq('Doe')
+      expect(response_json.dig('data', 'attributes', 'date_of_birth')).to eq('1991-12-01')
     end
 
     it 'creates a new applicant' do
@@ -46,7 +48,8 @@ RSpec.describe 'Legal aid applications' do
           'data': {
             'type': 'legal_aid_applicant',
             'attributes': {
-              'name': 'John Doe',
+              'first_name': 'John',
+              'last_name': 'Doe',
               'date_of_birth': '11-12-01',
               'application_ref': application.application_ref
             }

--- a/spec/requests/legalaid_application_spec.rb
+++ b/spec/requests/legalaid_application_spec.rb
@@ -3,9 +3,10 @@ require 'json_expressions/rspec'
 
 RSpec.describe 'Legal aid applications' do
   describe 'GET /v1/applications/:id' do
-    let(:applicant_name) { Faker::Name.name }
+    let(:applicant_first_name) { Faker::Name.first_name }
+    let(:applicant_last_name) { Faker::Name.last_name }
     let(:applicant_date_of_birth) { Faker::Date.birthday(18, 100) }
-    let(:applicant) { Applicant.create(name: applicant_name, date_of_birth: applicant_date_of_birth) }
+    let(:applicant) { Applicant.create(first_name: applicant_first_name, last_name: applicant_last_name, date_of_birth: applicant_date_of_birth) }
     let(:legal_aid_application) { LegalAidApplication.create(applicant: applicant) }
     let(:application_ref) { legal_aid_application.application_ref }
 
@@ -39,7 +40,8 @@ RSpec.describe 'Legal aid applications' do
           { 'id' => applicant.id.to_s,
             'type' => 'applicant',
             'attributes' =>
-            { 'name' => applicant_name,
+            { 'first_name' => applicant_first_name,
+              'last_name' => applicant_last_name,
               'date_of_birth' => applicant_date_of_birth.to_s } }
         ]
       }

--- a/spec/services/save_applicant_spec.rb
+++ b/spec/services/save_applicant_spec.rb
@@ -1,43 +1,45 @@
 require 'rails_helper'
 
 RSpec.describe SaveApplicant do
-  let(:name) { 'Rich' }
+  let(:first_name) { 'Rich' }
+  let(:last_name) { 'Ford' }
   let(:date_of_birth) { '1991-12-01' }
   let(:existing_application) { LegalAidApplication.create }
   let(:application_ref) { existing_application.application_ref }
 
   context 'When given valid values' do
     it 'should save the model' do
-      result = described_class.call(name: name, date_of_birth: date_of_birth, application_ref: application_ref)
+      result = described_class.call(first_name: first_name, last_name: last_name, date_of_birth: date_of_birth, application_ref: application_ref)
       expect(result.success?).to eq true
       expect(existing_application.reload.applicant).to eq result.applicant
-      expect(result.applicant.name).to eq name
+      expect(result.applicant.first_name).to eq first_name
+      expect(result.applicant.last_name).to eq last_name
     end
   end
 
   context 'When given invalid values' do
     let(:date_of_birth) { '11-11-11' }
     it 'should throw an error' do
-      result = described_class.call(name: name, date_of_birth: date_of_birth, application_ref: application_ref)
+      result = described_class.call(first_name: first_name, last_name: last_name, date_of_birth: date_of_birth, application_ref: application_ref)
       expect(result).not_to be_success
       expect(existing_application.reload.applicant).to be_nil
       expect(result.errors).to match(['Date of birth is not valid'])
     end
     it 'does not create a new applicant record' do
-      expect { described_class.call(name: name, date_of_birth: date_of_birth, application_ref: application_ref) }.to_not change(Applicant, :count)
+      expect { described_class.call(first_name: first_name, last_name: last_name, date_of_birth: date_of_birth, application_ref: application_ref) }.to_not change(Applicant, :count)
     end
   end
 
   context 'When given an invalid application reference' do
     let(:application_ref) { SecureRandom.uuid }
     it 'should throw an error' do
-      result = described_class.call(name: name, date_of_birth: date_of_birth, application_ref: application_ref)
+      result = described_class.call(first_name: first_name, last_name: last_name, date_of_birth: date_of_birth, application_ref: application_ref)
       expect(result).not_to be_success
       expect(result.errors).to match(['invalid application reference'])
     end
 
     it 'does not create a new applicant record' do
-      expect { described_class.call(name: name, date_of_birth: date_of_birth, application_ref: application_ref) }.to_not change(Applicant, :count)
+      expect { described_class.call(first_name: first_name, last_name: last_name, date_of_birth: date_of_birth, application_ref: application_ref) }.to_not change(Applicant, :count)
     end
   end
 end


### PR DESCRIPTION
Client name has been split out into two separate fields for first and last name

[Link to story](https://dsdmoj.atlassian.net/browse/AP-128)

As it stands the benefit checker requires letters from the surname in order to complete a successful request, and it was proving difficult to extract this information from a single client name field.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no uneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
