### PR TITLE
added /v1 in request path for proceeding types

### DIFF
--- a/app/controllers/proceeding_types_controller.rb
+++ b/app/controllers/proceeding_types_controller.rb
@@ -1,6 +1,0 @@
-class ProceedingTypesController < ApplicationController
-  def index
-    proceeding_types = ProceedingType.all
-    render json: ProceedingTypesSerializer.new(proceeding_types).serialized_json
-  end
-end

--- a/app/controllers/v1/proceeding_types_controller.rb
+++ b/app/controllers/v1/proceeding_types_controller.rb
@@ -1,0 +1,8 @@
+module V1
+  class ProceedingTypesController < ApplicationController
+    def index
+      proceeding_types = ProceedingType.all
+      render json: ProceedingTypesSerializer.new(proceeding_types).serialized_json
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,8 @@
 Rails.application.routes.draw do
   resources :status, only: [:index]
-  resources :proceeding_types, only: [:index]
 
   namespace 'v1' do
-    resources :status, only: [:index]
+    resources :proceeding_types, only: [:index]
     resources :applications, only: [:create, :show]
     resources :applicants
   end

--- a/spec/requests/proceeding_types_controller_spec.rb
+++ b/spec/requests/proceeding_types_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Proceeding types' do
     end
 
     it 'returns a proceeding types' do
-      get '/proceeding_types'
+      get '/v1/proceeding_types'
 
       expected_json =
 


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/AP-119

before proceeding types were retrieved with request path - /proceeding_types
with this change, it will be retrieved with request path - /v1/proceeding_types
and
removed the status endpoint which was hanging inside v1 namespace, it already exists outside.

this will fix the provider frontend rest call to API (for proceeding types)