### PR TITLE
Changed the path of the applicant patch url to be singular.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   namespace 'v1' do
     resources :proceeding_types, only: [:index]
     resources :applications, only: [:create, :show], param: :ref do
-      resource :applicants, only: [:update]
+      resource :applicant, only: [:update]
     end
     resources :applicants, only: [:create, :show]
   end

--- a/spec/requests/applicant_spec.rb
+++ b/spec/requests/applicant_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'Update Legal aid applications' do
     }
   end
 
-  describe 'PATCH /v1/applicants' do
+  describe 'PATCH /v1/applications/{app_ref}/applicant' do
     body = {
       'data': {
         'type': 'legal_aid_applicant',
@@ -102,7 +102,7 @@ RSpec.describe 'Update Legal aid applications' do
         }
       }
 
-      patch "/v1/applications/#{application.application_ref}/applicants/", params: body, headers: headers
+      patch "/v1/applications/#{application.application_ref}/applicant/", params: body, headers: headers
 
       expect(response.status).to eql(200)
       expect(response_json).to match_json_expression(expected_json)
@@ -117,20 +117,20 @@ RSpec.describe 'Update Legal aid applications' do
           }
         }
       }.to_json
-      patch "/v1/applications/#{application.application_ref}/applicants/", params: body_invalid_email, headers: headers
+      patch "/v1/applications/#{application.application_ref}/applicant/", params: body_invalid_email, headers: headers
       expect(response.status).to eql(400)
       expect(response.content_type).to eql('application/json')
       expect(response_json[0]).to eq('Email address is not in the right format')
     end
 
     it 'returns a 422 if a application is not found' do
-      patch "/v1/applications/this-ref-doesn't-exist/applicants/", params: body, headers: headers
+      patch "/v1/applications/this-ref-doesn't-exist/applicant/", params: body, headers: headers
       expect(response.status).to eql(422)
       expect(response_json['message']).to eql("Failed to find application with ref this-ref-doesn't-exist")
     end
 
     it 'returns a 404 if a applicant for application is not found' do
-      patch "/v1/applications/#{application_without_applicant.application_ref}/applicants/", params: body, headers: headers
+      patch "/v1/applications/#{application_without_applicant.application_ref}/applicant/", params: body, headers: headers
       expect(response.status).to eql(404)
       expect(response_json['message']).to eql("Failed to find applicant for application with ref #{application_without_applicant.application_ref}")
     end


### PR DESCRIPTION
## What
[Link to story](https://dsdmoj.atlassian.net/browse/AP-8)

Why:
Doing this makes it clear that the url points to a single applicant
resource related to the application.


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
