### PR TITLE
Migrate the database id's from sequential bigint to UUID

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.7'
   gem 'rubocop', require: false
   gem 'shoulda-matchers', '~> 3.1'
+  gem 'webdack-uuid_migration'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,8 @@ GEM
     uglifier (4.1.18)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.4.0)
+    webdack-uuid_migration (1.2.0)
+      activerecord (>= 4.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -232,6 +234,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   uglifier (>= 1.3.0)
+  webdack-uuid_migration
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,5 +7,9 @@ Bundler.require(*Rails.groups)
 module LaaApplyForLegalaidApi
   class Application < Rails::Application
     config.load_defaults 5.2
+
+    config.generators do |g|
+      g.orm :active_record, primary_key_type: :uuid
+    end
   end
 end

--- a/db/migrate/20181017202608_enable_pgcrypto_extension.rb
+++ b/db/migrate/20181017202608_enable_pgcrypto_extension.rb
@@ -1,0 +1,5 @@
+class EnablePgcryptoExtension < ActiveRecord::Migration[5.1]
+  def change
+    enable_extension 'pgcrypto'
+  end
+end

--- a/db/migrate/20181018165257_add_foreign_keys.rb
+++ b/db/migrate/20181018165257_add_foreign_keys.rb
@@ -1,0 +1,7 @@
+class AddForeignKeys < ActiveRecord::Migration[5.2]
+  def change
+    add_foreign_key :application_proceeding_types, :proceeding_types
+    add_foreign_key :application_proceeding_types, :legal_aid_applications
+    add_foreign_key :legal_aid_applications, :applicants
+  end
+end

--- a/db/migrate/20181018165405_id_to_uuid_fk.rb
+++ b/db/migrate/20181018165405_id_to_uuid_fk.rb
@@ -1,0 +1,18 @@
+require 'webdack/uuid_migration/helpers'
+
+class IdToUuidFk < ActiveRecord::Migration[5.2]
+  def change
+    reversible do |dir|
+      dir.up do
+
+        primary_key_and_all_references_to_uuid :applicants
+        primary_key_and_all_references_to_uuid :legal_aid_applications
+        primary_key_and_all_references_to_uuid :proceeding_types
+      end
+
+      dir.down do
+        raise ActiveRecord::IrreversibleMigration
+      end
+    end
+  end
+end

--- a/db/migrate/20181018165405_id_to_uuid_fk.rb
+++ b/db/migrate/20181018165405_id_to_uuid_fk.rb
@@ -4,7 +4,6 @@ class IdToUuidFk < ActiveRecord::Migration[5.2]
   def change
     reversible do |dir|
       dir.up do
-
         primary_key_and_all_references_to_uuid :applicants
         primary_key_and_all_references_to_uuid :legal_aid_applications
         primary_key_and_all_references_to_uuid :proceeding_types

--- a/db/migrate/20181018165537_uuid_migration.rb
+++ b/db/migrate/20181018165537_uuid_migration.rb
@@ -1,0 +1,17 @@
+require 'webdack/uuid_migration/helpers'
+
+class UuidMigration < ActiveRecord::Migration[5.2]
+  def change
+    reversible do |dir|
+      dir.up do
+
+        primary_key_to_uuid :addresses
+        primary_key_to_uuid :application_proceeding_types
+      end
+
+      dir.down do
+        raise ActiveRecord::IrreversibleMigration
+      end
+    end
+  end
+end

--- a/db/migrate/20181018165537_uuid_migration.rb
+++ b/db/migrate/20181018165537_uuid_migration.rb
@@ -4,7 +4,6 @@ class UuidMigration < ActiveRecord::Migration[5.2]
   def change
     reversible do |dir|
       dir.up do
-
         primary_key_to_uuid :addresses
         primary_key_to_uuid :application_proceeding_types
       end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_11_143410) do
+ActiveRecord::Schema.define(version: 2018_10_17_202608) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "addresses", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,25 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_17_202608) do
+ActiveRecord::Schema.define(version: 2018_10_18_165537) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  create_table "addresses", force: :cascade do |t|
+  create_table "addresses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "address_line_one"
     t.string "address_line_two"
     t.string "city"
     t.string "county"
     t.string "postcode"
-    t.bigint "applicant_id", null: false
+    t.uuid "applicant_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["applicant_id"], name: "index_addresses_on_applicant_id"
   end
 
-  create_table "applicants", force: :cascade do |t|
+  create_table "applicants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "first_name"
     t.date "date_of_birth"
     t.datetime "created_at", null: false
@@ -38,24 +38,24 @@ ActiveRecord::Schema.define(version: 2018_10_17_202608) do
     t.string "national_insurance_number"
   end
 
-  create_table "application_proceeding_types", force: :cascade do |t|
-    t.bigint "legal_aid_application_id"
-    t.bigint "proceeding_type_id"
+  create_table "application_proceeding_types", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "legal_aid_application_id"
+    t.uuid "proceeding_type_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["legal_aid_application_id"], name: "index_application_proceeding_types_on_legal_aid_application_id"
     t.index ["proceeding_type_id"], name: "index_application_proceeding_types_on_proceeding_type_id"
   end
 
-  create_table "legal_aid_applications", force: :cascade do |t|
+  create_table "legal_aid_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "application_ref"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "applicant_id"
+    t.uuid "applicant_id"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
   end
 
-  create_table "proceeding_types", force: :cascade do |t|
+  create_table "proceeding_types", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "code"
     t.string "ccms_code"
     t.string "meaning"
@@ -70,4 +70,7 @@ ActiveRecord::Schema.define(version: 2018_10_17_202608) do
   end
 
   add_foreign_key "addresses", "applicants"
+  add_foreign_key "application_proceeding_types", "legal_aid_applications"
+  add_foreign_key "application_proceeding_types", "proceeding_types"
+  add_foreign_key "legal_aid_applications", "applicants"
 end


### PR DESCRIPTION
The tables currently use sequential bigint to set the id. This change modifies the behaviour to use uuid instead.

The pgcrypto gem sets uuid as the default for all future tables that are created.
The webdack gem converts existing id fields to uuid and can be removed once the migrations have been run
Add foreign keys to existing references
Converts foreign keys on existing references to uuid
Convert all other id's (that are not foreign keys) to uuid

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
