### PR TITLE
Ignore git-crypt and Rails master keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@
 
 # Ignore node_modules
 node_modules/
+
+# Ignore git-crypt key and Rails master key
+git-crypt.key
+config/master.key


### PR DESCRIPTION
## What

**Ignore git-crypt and Rails master keys**

As they're being generated at the CircleCI deploy stage and git-cryptcan't unlock files with untracked files.

Should have been part of https://github.com/ministryofjustice/laa-apply-for-legalaid-api/pull/36 😓 