### PR TITLE
Update GITHUB_TEAM_NAME_SLUG to right conf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ references:
     docker:
     - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
       environment:
-        GITHUB_TEAM_NAME_SLUG: apply-for-legalaid
+        GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
 
   decrypt_secrets: &decrypt_secrets
     run:
@@ -18,7 +18,7 @@ references:
     docker:
     - image: circleci/ruby:2.5.1-node-browsers
       environment:
-        GITHUB_TEAM_NAME_SLUG: apply-for-legalaid
+        GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
     - image: postgres:10.5
 
   setup_test_env: &setup_test_env


### PR DESCRIPTION
## What

As we had two github teams setup and they were both being used for different purposes. This unifies all the configurations to use only one of those teams so we can make the other one obsolete.

Relates to: https://github.com/ministryofjustice/cloud-platform-environments/pull/233