### PR TITLE
Wait for Ajax calls to complete before assertions

### DIFF
--- a/features/providers/step_definitions/civil_journey_steps.rb
+++ b/features/providers/step_definitions/civil_journey_steps.rb
@@ -14,6 +14,7 @@ end
 
 And(/^I search for proceeding '(.*)'$/) do |proceeding_search|
   fill_in('proceeding-search-input', with: proceeding_search)
+  wait_for_ajax
 end
 
 When(/^I click clear search$/) do

--- a/features/support/wait_for_ajax.rb
+++ b/features/support/wait_for_ajax.rb
@@ -1,0 +1,13 @@
+module WaitForAjax
+  def wait_for_ajax(wait: Capybara.default_max_wait_time)
+    Timeout.timeout(wait) do
+      loop until finished_all_ajax_requests?
+    end
+  end
+
+  def finished_all_ajax_requests?
+    page.evaluate_script('jQuery.active').zero?
+  end
+end
+
+World(WaitForAjax)


### PR DESCRIPTION
## What

The page that allows the user to search for proceeding performs an AJAX call to retrieve the results.

The cucumber tests are not currently ensuring the AJAX call(s) were completed and attempts to immediately assert that the content is on the page, which can cause the assertions to fail.

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
